### PR TITLE
[CAFE-12] 메뉴 옵션 조회 기능 추가

### DIFF
--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/OptionController.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/OptionController.kt
@@ -1,0 +1,31 @@
+package com.devh.cafe.api.menu.controller
+
+import com.devh.cafe.api.common.response.PageResponse
+import com.devh.cafe.api.menu.controller.request.OptionGetRequest
+import com.devh.cafe.api.menu.controller.response.OptionData
+import com.devh.cafe.api.menu.service.OptionService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/option")
+@Validated
+class OptionController(
+    @Autowired
+    val optionService: OptionService,
+) {
+    @GetMapping("/menu/id/{id}")
+    fun getByMenuId(
+            @PathVariable("id") id: Long
+    ): PageResponse<OptionData> {
+        val optionPageData = optionService.getByMenuId(OptionGetRequest(menuId = id))
+        return PageResponse(
+                paging = optionPageData.paging,
+                list = optionPageData.list,
+        )
+    }
+}

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/request/OptionCreateRequest.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/request/OptionCreateRequest.kt
@@ -1,0 +1,11 @@
+package com.devh.cafe.api.menu.controller.request
+
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+
+data class OptionCreateRequest(
+    val type: OptionType,
+    val typeId: Long,
+    val name: String,
+    val displayOrder: Int,
+    val subOptions: SubOptionCreateRequest
+)

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/request/OptionGetRequest.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/request/OptionGetRequest.kt
@@ -1,0 +1,5 @@
+package com.devh.cafe.api.menu.controller.request
+
+data class OptionGetRequest(
+    val menuId: Long,
+)

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/request/SubOptionCreateRequest.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/request/SubOptionCreateRequest.kt
@@ -1,0 +1,12 @@
+package com.devh.cafe.api.menu.controller.request
+
+data class SubOptionCreateRequest(
+    val optionId: Long? = null,
+    val values: MutableList<SubOptionValue>,
+)
+
+data class SubOptionValue(
+    val name: String,
+    val price: Long,
+    val displayOrder: Int,
+)

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/response/MenuData.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/response/MenuData.kt
@@ -6,8 +6,7 @@ data class MenuData(
     val id: Long,
     val name: String,
     val price: Long,
-    val categoryId: Long,
-    val categoryName: String,
+    val category: CategorySimpleData,
     val available: Boolean,
 )
 

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/response/OptionData.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/controller/response/OptionData.kt
@@ -1,0 +1,23 @@
+package com.devh.cafe.api.menu.controller.response
+
+import com.devh.cafe.api.common.paging.Paging
+
+data class OptionData(
+    val id: Long,
+    val name: String,
+    val order: Int,
+    val type: String,
+    val subOptions: MutableList<SubOptionData>,
+)
+
+data class SubOptionData(
+    val id: Long,
+    val name: String,
+    val order: Int,
+    val price: Long,
+)
+
+data class OptionPageData(
+    val paging: Paging,
+    val list: MutableList<OptionData>,
+)

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/exception/Exceptions.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/exception/Exceptions.kt
@@ -19,3 +19,23 @@ val MSG_MENU_ALREADY_EXISTS = "이미 존재하는 메뉴입니다."
 fun menuAlreadyExists(): MenuException {
     return MenuException(MSG_MENU_ALREADY_EXISTS)
 }
+
+val MSG_OPTION_NOT_EXISTS = "존재하지 않는 옵션입니다."
+fun optionDoesNotExists(): OptionException {
+    return OptionException(MSG_OPTION_NOT_EXISTS)
+}
+
+val MSG_OPTION_ALREADY_EXISTS = "이미 존재하는 옵션입니다."
+fun optionAlreadyExists(): OptionException {
+    return OptionException(MSG_OPTION_ALREADY_EXISTS)
+}
+
+val MSG_SUB_OPTION_NOT_EXISTS = "존재하지 않는 하위 옵션입니다."
+fun subOptionDoesNotExists(): SubOptionException {
+    return SubOptionException(MSG_SUB_OPTION_NOT_EXISTS)
+}
+
+val MSG_SUB_OPTION_ALREADY_EXISTS = "이미 존재하는 하위 옵션입니다."
+fun subOptionAlreadyExists(): SubOptionException {
+    return SubOptionException(MSG_SUB_OPTION_ALREADY_EXISTS)
+}

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/exception/OptionException.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/exception/OptionException.kt
@@ -1,0 +1,5 @@
+package com.devh.cafe.api.menu.exception
+
+class OptionException(
+    override val message: String,
+): IllegalArgumentException()

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/exception/SubOptionException.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/exception/SubOptionException.kt
@@ -1,0 +1,5 @@
+package com.devh.cafe.api.menu.exception
+
+class SubOptionException(
+    override val message: String,
+): IllegalArgumentException()

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/CategoryRepository.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/CategoryRepository.kt
@@ -42,4 +42,32 @@ interface CategoryRepository : JpaRepository<Category, Long> {
         """
     )
     fun findSubCategoriesRecursiveByName(@Param(value = "name") name: String): MutableSet<Category>
+    @Query(
+        nativeQuery = true,
+        value = """
+            with recursive cte (id, name, parent) as (
+            select id, name, parent from category where id = :id
+            union all
+            select parent.id, parent.name, parent.parent
+            from category parent
+            inner join cte child on child.parent = parent.id
+            )
+            select id, name, parent from cte
+        """
+    )
+    fun findParentCategoriesRecursiveById(@Param(value = "id") id: Long): MutableSet<Category>
+    @Query(
+        nativeQuery = true,
+        value = """
+            with recursive cte (id, name, parent) as (
+            select id, name, parent from category where name = :name
+            union all
+            select parent.id, parent.name, parent.parent
+            from category parent
+            inner join cte child on child.parent = parent.id
+            )
+            select id, name, parent from cte
+        """
+    )
+    fun findParentCategoriesRecursiveByName(@Param(value = "name") name: String): MutableSet<Category>
 }

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/MenuQuerydslRepository.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/MenuQuerydslRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.domain.Pageable
 
 interface MenuQuerydslRepository {
     fun findPageByCategory(categoryId: Long, pageable: Pageable): Page<Menu>
+    fun findPageByCategories(categoryIds: MutableList<Long>, pageable: Pageable): Page<Menu>
 }

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/MenuQuerydslRepositoryImpl.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/MenuQuerydslRepositoryImpl.kt
@@ -35,4 +35,25 @@ class MenuQuerydslRepositoryImpl(
             .fetchOne() ?: 0
         return PageImpl(content, pageable, count)
     }
+
+    override fun findPageByCategories(categoryIds: MutableList<Long>, pageable: Pageable): Page<Menu> {
+        val qMenu = QMenu.menu
+        val qCategory = QCategory.category
+        val content = jpaQueryFactory
+            .select(qMenu)
+            .from(qMenu)
+            .join(qCategory)
+            .on(qMenu.category.id.eq(qCategory.id))
+            .where(qCategory.id.`in`(categoryIds))
+            .limit(pageable.pageSize.toLong())
+            .offset(pageable.offset)
+            .orderBy(qMenu.id.asc())
+            .fetch()
+        val count = jpaQueryFactory
+            .select(qMenu.count())
+            .from(qMenu)
+            .where(qMenu.category.id.`in`(categoryIds))
+            .fetchOne() ?: 0
+        return PageImpl(content, pageable, count)
+    }
 }

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/OptionQuerydslRepository.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/OptionQuerydslRepository.kt
@@ -1,0 +1,7 @@
+package com.devh.cafe.api.menu.repository
+
+import com.devh.cafe.infrastructure.database.entity.Option
+
+interface OptionQuerydslRepository {
+    fun findOptionsByCategoryIdInAndMenuId(categoryIds: MutableList<Long>, menuId: Long): MutableList<Option>
+}

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/OptionQuerydslRepositoryImpl.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/OptionQuerydslRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.devh.cafe.api.menu.repository
+
+import com.devh.cafe.infrastructure.database.entity.Option
+import com.devh.cafe.infrastructure.database.entity.QOption
+import com.devh.cafe.infrastructure.database.entity.QSubOption
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.beans.factory.annotation.Autowired
+
+class OptionQuerydslRepositoryImpl(
+    @Autowired
+    private val jpaQueryFactory: JPAQueryFactory,
+) : OptionQuerydslRepository {
+    override fun findOptionsByCategoryIdInAndMenuId(categoryIds: MutableList<Long>, menuId: Long): MutableList<Option> {
+        val qOption = QOption.option
+        val qSubOption = QSubOption.subOption
+        return jpaQueryFactory
+            .select(qOption)
+            .from(qOption)
+            .join(qSubOption)
+            .on(qOption.id.eq(qSubOption.option.id))
+            .where(qOption.category.id.`in`(categoryIds)
+                .or(qOption.menu.id.eq(menuId)))
+            .orderBy(qOption.displayOrder.asc(), qSubOption.displayOrder.asc())
+            .fetch()
+    }
+}

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/OptionRepository.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/repository/OptionRepository.kt
@@ -1,0 +1,9 @@
+package com.devh.cafe.api.menu.repository
+
+import com.devh.cafe.infrastructure.database.entity.Option
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface OptionRepository : JpaRepository<Option, Long>, OptionQuerydslRepository {
+    fun findByName(name: String): Optional<Option>
+}

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/CategoryService.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/CategoryService.kt
@@ -18,6 +18,8 @@ interface CategoryService {
     fun getSubCategoriesByParentId(categoryGetRequest: CategoryGetRequest): CategoryPageData
     fun getSubCategoryNamesRecursiveByName(name: String): MutableList<CategorySimpleData>
     fun getSubCategoryNamesRecursiveById(id: Long): MutableList<CategorySimpleData>
+    fun getParentCategoryNamesRecursiveByName(name: String): MutableList<CategorySimpleData>
+    fun getParentCategoryNamesRecursiveById(id: Long): MutableList<CategorySimpleData>
     fun update(categoryUpdateRequest: CategoryUpdateRequest): CategoryData
     fun delete(categoryDeleteRequest: CategoryDeleteRequest)
 }

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/CategoryServiceImpl.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/CategoryServiceImpl.kt
@@ -104,6 +104,18 @@ class CategoryServiceImpl(
             .toMutableList()
     }
 
+    override fun getParentCategoryNamesRecursiveByName(name: String): MutableList<CategorySimpleData> {
+        return categoryRepository.findParentCategoriesRecursiveByName(name)
+            .map { CategorySimpleData(id = it.id!!, name = it.name) }
+            .toMutableList()
+    }
+
+    override fun getParentCategoryNamesRecursiveById(id: Long): MutableList<CategorySimpleData> {
+        return categoryRepository.findParentCategoriesRecursiveById(id)
+            .map { CategorySimpleData(id = it.id!!, name = it.name) }
+            .toMutableList()
+    }
+
     @Transactional
     override fun update(categoryUpdateRequest: CategoryUpdateRequest): CategoryData {
         val category = categoryRepository.findById(categoryUpdateRequest.id).orElseThrow { categoryDoesNotExists() }

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/OptionService.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/OptionService.kt
@@ -1,0 +1,10 @@
+package com.devh.cafe.api.menu.service
+
+import com.devh.cafe.api.menu.controller.request.OptionCreateRequest
+import com.devh.cafe.api.menu.controller.request.OptionGetRequest
+import com.devh.cafe.api.menu.controller.response.OptionPageData
+
+interface OptionService {
+    fun createOption(optionCreateRequest: OptionCreateRequest)
+    fun getByMenuId(optionGetRequest: OptionGetRequest): OptionPageData
+}

--- a/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/OptionServiceImpl.kt
+++ b/api/menu-api/src/main/kotlin/com/devh/cafe/api/menu/service/OptionServiceImpl.kt
@@ -1,0 +1,114 @@
+package com.devh.cafe.api.menu.service
+
+import com.devh.cafe.api.common.paging.Paging
+import com.devh.cafe.api.menu.controller.request.OptionCreateRequest
+import com.devh.cafe.api.menu.controller.request.OptionGetRequest
+import com.devh.cafe.api.menu.controller.response.OptionData
+import com.devh.cafe.api.menu.controller.response.OptionPageData
+import com.devh.cafe.api.menu.controller.response.SubOptionData
+import com.devh.cafe.api.menu.exception.categoryDoesNotExists
+import com.devh.cafe.api.menu.exception.menuDoesNotExists
+import com.devh.cafe.api.menu.exception.optionAlreadyExists
+import com.devh.cafe.api.menu.repository.CategoryRepository
+import com.devh.cafe.api.menu.repository.MenuRepository
+import com.devh.cafe.api.menu.repository.OptionRepository
+import com.devh.cafe.infrastructure.database.entity.Option
+import com.devh.cafe.infrastructure.database.entity.SubOption
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+import jakarta.transaction.Transactional
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class OptionServiceImpl(
+    @Autowired
+    val categoryRepository: CategoryRepository,
+
+    @Autowired
+    val menuRepository: MenuRepository,
+
+    @Autowired
+    val optionRepository: OptionRepository,
+) : OptionService {
+    private val log: Logger = LoggerFactory.getLogger(this.javaClass)!!
+
+    @Transactional
+    override fun createOption(optionCreateRequest: OptionCreateRequest) {
+        val newOption = when(optionCreateRequest.type) {
+            OptionType.MENU -> {
+                val menu = menuRepository.findById(optionCreateRequest.typeId).orElseThrow { menuDoesNotExists() }
+                Option(
+                    name = optionCreateRequest.name,
+                    displayOrder = optionCreateRequest.displayOrder,
+                    type = OptionType.MENU,
+                    menu = menu
+                )
+            }
+            OptionType.CATEGORY -> {
+                val category = categoryRepository.findById(optionCreateRequest.typeId).orElseThrow { categoryDoesNotExists() }
+                Option(
+                    name = optionCreateRequest.name,
+                    displayOrder = optionCreateRequest.displayOrder,
+                    type = OptionType.CATEGORY,
+                    category = category
+                )
+            }
+        }
+
+        optionCreateRequest.subOptions.values.forEach {
+            SubOption(
+                name = it.name,
+                price = it.price,
+                displayOrder = it.displayOrder,
+                option = newOption
+            )
+        }
+
+        optionRepository.findByName(optionCreateRequest.name).ifPresentOrElse(
+            { throw optionAlreadyExists() },
+            { optionRepository.save(newOption) }
+        )
+    }
+
+    override fun getByMenuId(optionGetRequest: OptionGetRequest): OptionPageData {
+        val menu = menuRepository.findById(optionGetRequest.menuId).orElseThrow { menuDoesNotExists() }
+        val categoryIds = categoryRepository.findParentCategoriesRecursiveById(menu.category.id!!).map { it.id!! }.toMutableList()
+        val options = optionRepository.findOptionsByCategoryIdInAndMenuId(categoryIds = categoryIds, menuId = menu.id!!)
+        val optionDataList = options.map(this::convertToOptionData).toMutableList()
+
+        return OptionPageData(
+                paging = Paging(
+                        page = 1,
+                        total = options.size.toLong(),
+                        first = false,
+                        last = false,
+                        next = false,
+                        prev = false,
+                ),
+                list = optionDataList
+        )
+    }
+
+    fun convertToOptionData(option: Option): OptionData {
+        val subOptions = option.subOptions
+
+        val subOptionDataList = subOptions.map {
+            SubOptionData(
+                    id = it.id!!,
+                    name = it.name,
+                    order = it.displayOrder,
+                    price = it.price
+            )
+        }.toMutableList()
+
+        return OptionData(
+                id = option.id!!,
+                name = option.name,
+                order = option.displayOrder,
+                type = option.type.name,
+                subOptions = subOptionDataList
+        )
+    }
+}

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/controller/MenuControllerUnitTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/controller/MenuControllerUnitTest.kt
@@ -7,6 +7,7 @@ import com.devh.cafe.api.menu.controller.request.MenuDeleteRequest
 import com.devh.cafe.api.menu.controller.request.MenuGetRequest
 import com.devh.cafe.api.menu.controller.request.MenuGetType
 import com.devh.cafe.api.menu.controller.request.MenuUpdateRequest
+import com.devh.cafe.api.menu.controller.response.CategorySimpleData
 import com.devh.cafe.api.menu.controller.response.MenuData
 import com.devh.cafe.api.menu.controller.response.MenuPageData
 import com.devh.cafe.api.menu.exception.CategoryException
@@ -56,8 +57,7 @@ class MenuControllerUnitTest {
                     id = givenId,
                     name = givenName,
                     price = givenPrice,
-                    categoryId = givenCategoryId,
-                    categoryName = givenCategoryName,
+                    category = CategorySimpleData(id = givenCategoryId, name = givenCategoryName),
                     available = givenAvailable
                 )
             )
@@ -99,6 +99,7 @@ class MenuControllerUnitTest {
         // given
         val givenCategoryId = 1L
         val givenCategoryName = "카테고리"
+        val givenCategory = CategorySimpleData(id = givenCategoryId, name = givenCategoryName)
         val givenPage = 1
         val givenSize = 10
         val givenMenuPageData = MenuPageData(
@@ -115,22 +116,19 @@ class MenuControllerUnitTest {
                     id = 1L,
                     name = "메뉴1",
                     price = 1000L,
-                    categoryId = givenCategoryId,
-                    categoryName = givenCategoryName,
+                    category = givenCategory,
                     available = true),
                 MenuData(
                     id = 2L,
                     name = "카테고리2",
                     price = 2000L,
-                    categoryId = givenCategoryId,
-                    categoryName = givenCategoryName,
+                    category = givenCategory,
                     available = true),
                 MenuData(
                     id = 3L,
                     name = "카테고리3",
                     price = 3000L,
-                    categoryId = givenCategoryId,
-                    categoryName = givenCategoryName,
+                    category = givenCategory,
                     available = true),
             )
         )
@@ -185,6 +183,7 @@ class MenuControllerUnitTest {
         // given
         val givenCategoryId = 1L
         val givenCategoryName = "카테고리"
+        val givenCategory = CategorySimpleData(id = givenCategoryId, name = givenCategoryName)
         val givenPage = 1
         val givenSize = 10
         val givenMenuPageData = MenuPageData(
@@ -201,22 +200,19 @@ class MenuControllerUnitTest {
                     id = 1L,
                     name = "메뉴1",
                     price = 1000L,
-                    categoryId = givenCategoryId,
-                    categoryName = givenCategoryName,
+                    category = givenCategory,
                     available = true),
                 MenuData(
                     id = 2L,
                     name = "카테고리2",
                     price = 2000L,
-                    categoryId = givenCategoryId,
-                    categoryName = givenCategoryName,
+                    category = givenCategory,
                     available = true),
                 MenuData(
                     id = 3L,
                     name = "카테고리3",
                     price = 3000L,
-                    categoryId = givenCategoryId,
-                    categoryName = givenCategoryName,
+                    category = givenCategory,
                     available = true),
             )
         )
@@ -289,8 +285,7 @@ class MenuControllerUnitTest {
                 id = givenId,
                 name = givenName,
                 price = givenPrice,
-                categoryId = givenCategoryId,
-                categoryName = givenCategoryName,
+                category = CategorySimpleData(id = givenCategoryId, name = givenCategoryName),
                 available = givenAvailable),
         )
         // when

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/controller/OptionControllerIntegrationTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/controller/OptionControllerIntegrationTest.kt
@@ -1,0 +1,39 @@
+package com.devh.cafe.api.menu.controller
+
+import com.devh.cafe.api.menu.controller.configuration.ControllerTest
+import com.devh.cafe.infrastructure.database.fixture.fixtureMenuAmericano
+import com.devh.cafe.infrastructure.database.fixture.fixtureOptionsAmericano
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@ControllerTest
+class OptionControllerIntegrationTest(
+    @Autowired
+    val mockMvc: MockMvc,
+
+) {
+
+    private val urlPrefix: String = "/v1/option"
+
+    @Test
+    fun 메뉴_아이디가_주어질_때_옵션_조회에_성공한다() {
+        // given
+        val givenMenu = fixtureMenuAmericano
+        val givenOptions = fixtureOptionsAmericano
+        // when & then
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("$urlPrefix/menu/id/${givenMenu.id!!}")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(200))
+            .andDo(MockMvcResultHandlers.print())
+            .andReturn()
+
+    }
+}

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/controller/OptionControllerUnitTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/controller/OptionControllerUnitTest.kt
@@ -1,0 +1,74 @@
+package com.devh.cafe.api.menu.controller
+
+import com.devh.cafe.api.common.paging.Paging
+import com.devh.cafe.api.menu.controller.request.OptionGetRequest
+import com.devh.cafe.api.menu.controller.response.OptionData
+import com.devh.cafe.api.menu.controller.response.OptionPageData
+import com.devh.cafe.api.menu.controller.response.SubOptionData
+import com.devh.cafe.api.menu.service.OptionService
+import com.devh.cafe.infrastructure.database.fixture.fixtureMenuAmericano
+import com.devh.cafe.infrastructure.database.fixture.fixtureOptionsAmericano
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class OptionControllerUnitTest {
+    @InjectMocks
+    lateinit var optionController: OptionController
+
+    @Mock
+    lateinit var optionService: OptionService
+
+    @Test
+    fun 메뉴_아이디가_주어질_때_옵션_조회에_성공한다() {
+        // given
+        val givenMenu = fixtureMenuAmericano
+        val givenOptions = fixtureOptionsAmericano
+        val givenRequest = OptionGetRequest(
+            menuId = givenMenu.id!!
+        )
+        Mockito.`when`(
+            optionService.getByMenuId(givenRequest)
+        ).thenReturn(
+            OptionPageData(
+                paging = Paging(
+                    page = 1,
+                    total = givenOptions.size.toLong(),
+                    first = true,
+                    last = true,
+                    next = false,
+                    prev = false,
+                ),
+                list = givenOptions.map {
+                    OptionData(
+                        id = it.id!!,
+                        name = it.name,
+                        order = it.displayOrder,
+                        type = it.type.toString(),
+                        subOptions = it.subOptions.map {subIt ->
+                            SubOptionData(
+                                id = subIt.id!!,
+                                name = subIt.name,
+                                order = subIt.displayOrder,
+                                price = subIt.price,
+                            )
+                        }.toMutableList(),
+                    )
+                }.toMutableList()
+            )
+        )
+        // when
+        val pageResponse = optionController.getByMenuId(givenMenu.id!!)
+        // then
+        assertAll(
+            { Assertions.assertEquals(200, pageResponse.status) },
+            { Assertions.assertEquals(givenOptions.size, pageResponse.list.size) },
+        )
+    }
+}

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/repository/CategoryRepositoryTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/repository/CategoryRepositoryTest.kt
@@ -5,6 +5,8 @@ import com.devh.cafe.infrastructure.database.entity.Category
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryBeverage
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryBeverageRecursiveSubCategories
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryBeverageSubCategories
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeine
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeineRecursiveParentCategories
 import com.devh.cafe.infrastructure.database.fixture.newCategory
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -96,4 +98,38 @@ class CategoryRepositoryTest(
             { assertTrue(categoryNames.containsAll(givenRecursiveSubCategoryNames)) },
         )
     }
+
+    @Test
+    fun 특정_카테고리_아이디_상위의_모든_카테고리명을_조회한다() {
+        // given
+        val givenMainCategoryId = fixtureCategoryCaffeine.id!!
+        val givenRecursiveParentCategoryNames = fixtureCategoryCaffeineRecursiveParentCategories.map { it.name }
+        // when
+        val parentCategories = categoryRepository.findParentCategoriesRecursiveById(id = givenMainCategoryId)
+        val categoryNames = parentCategories.map { it.name }
+        // then
+        assertAll(
+                { assertTrue(givenRecursiveParentCategoryNames.size == categoryNames.size) },
+                { assertTrue(givenRecursiveParentCategoryNames.containsAll(categoryNames)) },
+                { assertTrue(categoryNames.containsAll(givenRecursiveParentCategoryNames)) },
+        )
+    }
+
+    @Test
+    fun 특정_카테고리명_상위의_모든_카테고리명을_조회한다() {
+        // given
+        val givenMainCategoryName = fixtureCategoryCaffeine.name
+        val givenRecursiveParentCategoryNames = fixtureCategoryCaffeineRecursiveParentCategories.map { it.name }
+        // when
+        val mainCategory = categoryRepository.findByName(givenMainCategoryName).get()
+        val parentCategories = categoryRepository.findParentCategoriesRecursiveByName(name = mainCategory.name)
+        val categoryNames = parentCategories.map { it.name }
+        // then
+        assertAll(
+                { assertTrue(givenRecursiveParentCategoryNames.size == categoryNames.size) },
+                { assertTrue(givenRecursiveParentCategoryNames.containsAll(categoryNames)) },
+                { assertTrue(categoryNames.containsAll(givenRecursiveParentCategoryNames)) },
+        )
+    }
+
 }

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/repository/MenuRepositoryTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/repository/MenuRepositoryTest.kt
@@ -4,6 +4,9 @@ import com.devh.cafe.api.menu.repository.configuration.RepositoryTest
 import com.devh.cafe.infrastructure.database.entity.Menu
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryBeverage
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeine
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCoffee
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryDecaffeine
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryFlatccino
 import com.devh.cafe.infrastructure.database.fixture.fixtureMenuAmericano
 import com.devh.cafe.infrastructure.database.fixture.newMenu
 import org.junit.jupiter.api.Assertions.assertAll
@@ -70,6 +73,28 @@ class MenuRepositoryTest(
         assertAll(
             { assertNotNull(page.content) },
             { assertEquals(limit, page.content.size) },
+        )
+    }
+
+    @Test
+    fun 여러_카테고리_id가_주어질_때_관련_메뉴의_페이지_조회에_성공한다() {
+        // given
+        val givenCategoryIds = mutableListOf(fixtureCategoryBeverage.id!!,
+                                             fixtureCategoryCoffee.id!!,
+                                             fixtureCategoryFlatccino.id!!,
+                                             fixtureCategoryCaffeine.id!!,
+                                             fixtureCategoryDecaffeine.id!!)
+        val limit = 4
+        val pageNum = 1
+        val pageable: Pageable = PageRequest.of(pageNum - 1, limit)
+        // when
+        val page: Page<Menu> =
+                menuRepository.findPageByCategories(categoryIds = givenCategoryIds, pageable = pageable)
+        page.content.forEach(System.out::println)
+        // then
+        assertAll(
+                { assertNotNull(page.content) },
+                { assertEquals(limit, page.content.size) },
         )
     }
 }

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/repository/OptionRepositoryTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/repository/OptionRepositoryTest.kt
@@ -1,0 +1,36 @@
+package com.devh.cafe.api.menu.repository
+
+import com.devh.cafe.api.menu.repository.configuration.RepositoryTest
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeineRecursiveParentCategories
+import com.devh.cafe.infrastructure.database.fixture.fixtureMenuAmericano
+import com.devh.cafe.infrastructure.database.fixture.fixtureOptionsAmericano
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+@RepositoryTest
+class OptionRepositoryTest(
+    @Autowired
+    val optionRepository: OptionRepository
+) {
+    @Test
+    fun 특정_메뉴의_옵션값을_조회한다() {
+        // given
+        val givenMenu = fixtureMenuAmericano
+        val givenCategories = fixtureCategoryCaffeineRecursiveParentCategories
+        val givenOptions = fixtureOptionsAmericano
+        // when
+        val expected =
+            optionRepository.findOptionsByCategoryIdInAndMenuId(
+                    categoryIds = givenCategories.map { it.id!! }.toMutableList(),
+                    menuId = givenMenu.id!!)
+        // then
+        assertAll(
+            { assertEquals(givenOptions.size, expected.size) },
+            { assertTrue(givenOptions.containsAll(expected)) },
+            { assertTrue(expected.containsAll(givenOptions)) },
+        )
+    }
+}

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/CategoryServiceIntegrationTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/CategoryServiceIntegrationTest.kt
@@ -13,6 +13,7 @@ import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryBeverage
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryBeverageRecursiveSubCategories
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryBeverageSubCategories
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeine
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeineRecursiveParentCategories
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryDecaffeine
 import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryFlatccino
 import com.devh.cafe.infrastructure.database.fixture.newCategory
@@ -194,6 +195,38 @@ class CategoryServiceIntegrationTest(
             { assertEquals(givenRecursiveSubCategoryNames.size, subCategoryNames.size) },
             { assertTrue(givenRecursiveSubCategoryNames.containsAll(subCategoryNames)) },
             { assertTrue(subCategoryNames.containsAll(givenRecursiveSubCategoryNames)) },
+        )
+    }
+
+    @Test
+    fun 특정_카테고리_아이디_상위의_모든_카테고리명을_조회한다() {
+        // given
+        val givenChildCategoryId = fixtureCategoryCaffeine.id!!
+        val givenRecursiveParentCategoryNames = fixtureCategoryCaffeineRecursiveParentCategories.map { it.name }
+        // when
+        val parentCategories = categoryService.getParentCategoryNamesRecursiveById(id = givenChildCategoryId)
+        val categoryNames = parentCategories.map { it.name }
+        // then
+        assertAll(
+            { assertTrue(givenRecursiveParentCategoryNames.size == categoryNames.size) },
+            { assertTrue(givenRecursiveParentCategoryNames.containsAll(categoryNames)) },
+            { assertTrue(categoryNames.containsAll(givenRecursiveParentCategoryNames)) },
+        )
+    }
+
+    @Test
+    fun 특정_카테고리명_상위의_모든_카테고리명을_조회한다() {
+        // given
+        val givenChildCategoryName = fixtureCategoryCaffeine.name!!
+        val givenRecursiveParentCategoryNames = fixtureCategoryCaffeineRecursiveParentCategories.map { it.name }
+        // when
+        val parentCategories = categoryService.getParentCategoryNamesRecursiveByName(name = givenChildCategoryName)
+        val categoryNames = parentCategories.map { it.name }
+        // then
+        assertAll(
+            { assertTrue(givenRecursiveParentCategoryNames.size == categoryNames.size) },
+            { assertTrue(givenRecursiveParentCategoryNames.containsAll(categoryNames)) },
+            { assertTrue(categoryNames.containsAll(givenRecursiveParentCategoryNames)) },
         )
     }
 

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/CategoryServiceUnitTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/CategoryServiceUnitTest.kt
@@ -9,6 +9,8 @@ import com.devh.cafe.api.menu.exception.MSG_CATEGORY_ALREADY_EXISTS
 import com.devh.cafe.api.menu.exception.MSG_CATEGORY_NOT_EXISTS
 import com.devh.cafe.api.menu.repository.CategoryRepository
 import com.devh.cafe.infrastructure.database.entity.Category
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeine
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeineRecursiveParentCategories
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -368,6 +370,48 @@ class CategoryServiceUnitTest {
             { assertEquals(givenCategoryNames.size, subCategoryNames.size) },
             { assertTrue(givenCategoryNames.containsAll(subCategoryNames)) },
             { assertTrue(subCategoryNames.containsAll(givenCategoryNames)) },
+        )
+    }
+
+    @Test
+    fun 특정_카테고리_아이디_상위의_모든_카테고리명을_조회한다() {
+        // given
+        val givenChildCategoryId = fixtureCategoryCaffeine.id!!
+        `when`(
+            categoryRepository.findParentCategoriesRecursiveById(givenChildCategoryId)
+        ).thenReturn(
+            fixtureCategoryCaffeineRecursiveParentCategories.toMutableSet()
+        )
+        val givenRecursiveParentCategoryNames = fixtureCategoryCaffeineRecursiveParentCategories.map { it.name }
+        // when
+        val parentCategories = categoryService.getParentCategoryNamesRecursiveById(id = givenChildCategoryId)
+        val categoryNames = parentCategories.map { it.name }
+        // then
+        assertAll(
+            { assertTrue(givenRecursiveParentCategoryNames.size == categoryNames.size) },
+            { assertTrue(givenRecursiveParentCategoryNames.containsAll(categoryNames)) },
+            { assertTrue(categoryNames.containsAll(givenRecursiveParentCategoryNames)) },
+        )
+    }
+
+    @Test
+    fun 특정_카테고리명_상위의_모든_카테고리명을_조회한다() {
+        // given
+        val givenChildCategoryName = fixtureCategoryCaffeine.name!!
+        `when`(
+            categoryRepository.findParentCategoriesRecursiveByName(givenChildCategoryName)
+        ).thenReturn(
+            fixtureCategoryCaffeineRecursiveParentCategories.toMutableSet()
+        )
+        val givenRecursiveParentCategoryNames = fixtureCategoryCaffeineRecursiveParentCategories.map { it.name }
+        // when
+        val parentCategories = categoryService.getParentCategoryNamesRecursiveByName(name = givenChildCategoryName)
+        val categoryNames = parentCategories.map { it.name }
+        // then
+        assertAll(
+            { assertTrue(givenRecursiveParentCategoryNames.size == categoryNames.size) },
+            { assertTrue(givenRecursiveParentCategoryNames.containsAll(categoryNames)) },
+            { assertTrue(categoryNames.containsAll(givenRecursiveParentCategoryNames)) },
         )
     }
 

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/MenuServiceIntegrationTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/MenuServiceIntegrationTest.kt
@@ -126,13 +126,12 @@ class MenuServiceIntegrationTest(
     @Test
     fun 카테고리_이름이_주어질_때_관련된_메뉴_조회에_성공한다() {
         // given
-        val givenCategory = fixtureCategoryCoffee
-        val givenMenu = fixtureMenu(category = fixtureCategoryCoffee)
+        val givenMenu = fixtureMenu(category = fixtureCategoryCaffeine)
         val givenMenuGetRequest = MenuGetRequest(
             page = 1,
             size = 10,
             type = MenuGetType.BY_CATEGORY_NAME,
-            categoryName = fixtureCategoryCoffee.name,
+            categoryName = fixtureCategoryCaffeine.name,
         )
         // when
         val menuPageData = menuService.get(givenMenuGetRequest)

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/MenuServiceUnitTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/MenuServiceUnitTest.kt
@@ -156,14 +156,14 @@ class MenuServiceUnitTest {
             Menu(id = 3, name = "메뉴3", price = 3500L, category = givenCategory),
         )
         `when`(
-            categoryRepository.findById(givenCategory.id!!)
+            categoryRepository.findSubCategoriesRecursiveById(givenCategory.id!!)
         ).thenReturn(
-            Optional.of(givenCategory)
+            mutableSetOf(givenCategory)
         )
 
         `when`(
-            menuRepository.findPageByCategory(
-                givenCategory.id!!,
+            menuRepository.findPageByCategories(
+                mutableListOf(givenCategory.id!!),
                 PageRequest.of(givenMenuGetRequest.page - 1, givenMenuGetRequest.size))
         ).thenReturn(
             PageImpl(list, Pageable.ofSize(givenMenuGetRequest.size), list.size.toLong())
@@ -188,9 +188,9 @@ class MenuServiceUnitTest {
             categoryId = givenUnknownCategoryId,
         )
         `when`(
-            categoryRepository.findById(givenUnknownCategoryId)
-        ).thenThrow(
-            categoryDoesNotExists()
+            categoryRepository.findSubCategoriesRecursiveById(givenUnknownCategoryId)
+        ).thenReturn(
+            mutableSetOf()
         )
         // when & then
         val assertThrows = assertThrows(
@@ -216,14 +216,14 @@ class MenuServiceUnitTest {
             Menu(id = 3, name = "메뉴3", price = 3500L, category = givenCategory),
         )
         `when`(
-            categoryRepository.findByName(givenCategory.name)
+            categoryRepository.findSubCategoriesRecursiveByName(givenCategory.name)
         ).thenReturn(
-            Optional.of(givenCategory)
+            mutableSetOf(givenCategory)
         )
 
         `when`(
-            menuRepository.findPageByCategory(
-                givenCategory.id!!,
+            menuRepository.findPageByCategories(
+                mutableListOf(givenCategory.id!!),
                 PageRequest.of(givenMenuGetRequest.page - 1, givenMenuGetRequest.size))
         ).thenReturn(
             PageImpl(list, Pageable.ofSize(givenMenuGetRequest.size), list.size.toLong())
@@ -248,9 +248,9 @@ class MenuServiceUnitTest {
             categoryName = givenUnknownCategoryName,
         )
         `when`(
-            categoryRepository.findByName(givenUnknownCategoryName)
-        ).thenThrow(
-            categoryDoesNotExists()
+            categoryRepository.findSubCategoriesRecursiveByName(givenUnknownCategoryName)
+        ).thenReturn(
+            mutableSetOf()
         )
         // when & then
         val assertThrows = assertThrows(
@@ -272,14 +272,14 @@ class MenuServiceUnitTest {
         )
         val list = emptyList<Menu>()
         `when`(
-            categoryRepository.findByName(givenCategory.name)
+            categoryRepository.findSubCategoriesRecursiveByName(givenCategory.name)
         ).thenReturn(
-            Optional.of(givenCategory)
+            mutableSetOf(givenCategory)
         )
 
         `when`(
-            menuRepository.findPageByCategory(
-                givenCategory.id!!,
+            menuRepository.findPageByCategories(
+                mutableListOf(givenCategory.id!!),
                 PageRequest.of(givenMenuGetRequest.page - 1, givenMenuGetRequest.size))
         ).thenReturn(
             PageImpl(list, Pageable.ofSize(givenMenuGetRequest.size), list.size.toLong())
@@ -333,8 +333,8 @@ class MenuServiceUnitTest {
             { assertEquals(givenName, menuData.name) },
             { assertEquals(givenPrice, menuData.price) },
             { assertEquals(givenAvailable, menuData.available) },
-            { assertEquals(givenNewCategory.id, menuData.categoryId) },
-            { assertEquals(givenNewCategory.name, menuData.categoryName) },
+            { assertEquals(givenNewCategory.id, menuData.category.id) },
+            { assertEquals(givenNewCategory.name, menuData.category.name) },
         )
     }
 

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/OptionServiceIntegrationTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/OptionServiceIntegrationTest.kt
@@ -1,0 +1,173 @@
+package com.devh.cafe.api.menu.service
+
+import com.devh.cafe.api.menu.controller.request.OptionCreateRequest
+import com.devh.cafe.api.menu.controller.request.OptionGetRequest
+import com.devh.cafe.api.menu.controller.request.SubOptionCreateRequest
+import com.devh.cafe.api.menu.controller.request.SubOptionValue
+import com.devh.cafe.api.menu.exception.CategoryException
+import com.devh.cafe.api.menu.exception.MSG_CATEGORY_NOT_EXISTS
+import com.devh.cafe.api.menu.exception.MSG_MENU_NOT_EXISTS
+import com.devh.cafe.api.menu.exception.MSG_OPTION_ALREADY_EXISTS
+import com.devh.cafe.api.menu.exception.MenuException
+import com.devh.cafe.api.menu.exception.OptionException
+import com.devh.cafe.api.menu.service.configuration.ServiceTest
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCoffee
+import com.devh.cafe.infrastructure.database.fixture.fixtureMenuAmericano
+import com.devh.cafe.infrastructure.database.fixture.fixtureOptionShot
+import com.devh.cafe.infrastructure.database.fixture.fixtureOptionsAmericano
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.beans.factory.annotation.Autowired
+
+@ServiceTest
+class OptionServiceIntegrationTest(
+    @Autowired
+    val optionService: OptionService,
+) {
+    @Test
+    fun 카테고리_타입의_새로운_옵션을_생성한다() {
+        // given
+        val givenOptionType = OptionType.CATEGORY
+        val givenCategory = fixtureCategoryCoffee
+        val givenTypeId = givenCategory.id!!
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        // when & then
+        assertDoesNotThrow { optionService.createOption(givenRequest) }
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리_타입의_새로운_옵션을_생성한다() {
+        // given
+        val givenOptionType = OptionType.CATEGORY
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = -1,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        // when
+        val assertThrows = Assertions.assertThrows(CategoryException::class.java) { optionService.createOption(givenRequest) }
+        // when & then
+        Assertions.assertEquals(assertThrows.message, MSG_CATEGORY_NOT_EXISTS)
+    }
+
+    @Test
+    fun 메뉴_타입의_새로운_옵션을_생성한다() {
+        // given
+        val givenOptionType = OptionType.MENU
+        val givenMenu = fixtureMenuAmericano
+        val givenTypeId = givenMenu.id!!
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        // when & then
+        assertDoesNotThrow { optionService.createOption(givenRequest) }
+    }
+
+    @Test
+    fun 존재하지_않는_메뉴_타입의_새로운_옵션을_생성한다() {
+        // given
+        val givenOptionType = OptionType.MENU
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = -1,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        // when
+        val assertThrows = Assertions.assertThrows(MenuException::class.java) { optionService.createOption(givenRequest) }
+        // when & then
+        Assertions.assertEquals(assertThrows.message, MSG_MENU_NOT_EXISTS)
+    }
+
+    @Test
+    fun 존재하는_옵션명으로_생성한다() {
+        // given
+        val givenOptionType = OptionType.MENU
+        val givenMenu = fixtureMenuAmericano
+        val givenTypeId = givenMenu.id!!
+        val givenName = fixtureOptionShot.name
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        // when
+        val assertThrows = Assertions.assertThrows(OptionException::class.java) { optionService.createOption(givenRequest) }
+        // when & then
+        Assertions.assertEquals(assertThrows.message, MSG_OPTION_ALREADY_EXISTS)
+    }
+
+    @Test
+    fun 특정_메뉴의_옵션을_조회한다() {
+        // given
+        val givenMenu = fixtureMenuAmericano
+        val givenRequest = OptionGetRequest(menuId = givenMenu.id!!)
+        val givenOptions = fixtureOptionsAmericano
+        val givenOptionNames = fixtureOptionsAmericano.map { it.name }
+        // when
+        val expected = optionService.getByMenuId(optionGetRequest = givenRequest)
+        val expectedOptionNames = expected.list.map { it.name }
+        // then
+        Assertions.assertAll(
+                { Assertions.assertEquals(givenOptions.size, expected.list.size) },
+                { Assertions.assertTrue(givenOptionNames.containsAll(expectedOptionNames)) },
+                { Assertions.assertTrue(expectedOptionNames.containsAll(givenOptionNames)) },
+        )
+    }
+
+    @Test
+    fun 존재하지_않는_메뉴의_옵션을_조회한다() {
+        // given
+        val givenRequest = OptionGetRequest(menuId = -1)
+        // when
+        val assertThrows = Assertions.assertThrows(MenuException::class.java) { optionService.getByMenuId(optionGetRequest = givenRequest) }
+        // then
+        Assertions.assertEquals(assertThrows.message, MSG_MENU_NOT_EXISTS)
+    }
+}

--- a/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/OptionServiceUnitTest.kt
+++ b/api/menu-api/src/test/kotlin/com/devh/cafe/api/menu/service/OptionServiceUnitTest.kt
@@ -1,0 +1,264 @@
+package com.devh.cafe.api.menu.service
+
+import com.devh.cafe.api.menu.controller.request.OptionCreateRequest
+import com.devh.cafe.api.menu.controller.request.OptionGetRequest
+import com.devh.cafe.api.menu.controller.request.SubOptionCreateRequest
+import com.devh.cafe.api.menu.controller.request.SubOptionValue
+import com.devh.cafe.api.menu.exception.CategoryException
+import com.devh.cafe.api.menu.exception.MSG_CATEGORY_NOT_EXISTS
+import com.devh.cafe.api.menu.exception.MSG_MENU_NOT_EXISTS
+import com.devh.cafe.api.menu.exception.MSG_OPTION_ALREADY_EXISTS
+import com.devh.cafe.api.menu.exception.MenuException
+import com.devh.cafe.api.menu.exception.OptionException
+import com.devh.cafe.api.menu.repository.CategoryRepository
+import com.devh.cafe.api.menu.repository.MenuRepository
+import com.devh.cafe.api.menu.repository.OptionRepository
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCaffeineRecursiveParentCategories
+import com.devh.cafe.infrastructure.database.fixture.fixtureCategoryCoffee
+import com.devh.cafe.infrastructure.database.fixture.fixtureMenuAmericano
+import com.devh.cafe.infrastructure.database.fixture.fixtureOptionShot
+import com.devh.cafe.infrastructure.database.fixture.fixtureOptionsAmericano
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class OptionServiceUnitTest {
+    @Mock
+    lateinit var categoryRepository: CategoryRepository
+
+    @Mock
+    lateinit var menuRepository: MenuRepository
+
+    @Mock
+    lateinit var optionRepository: OptionRepository
+
+    @InjectMocks
+    lateinit var optionService: OptionServiceImpl
+
+    @Test
+    fun 카테고리_타입의_새로운_옵션을_생성한다() {
+        // given
+        val givenOptionType = OptionType.CATEGORY
+        val givenCategory = fixtureCategoryCoffee
+        val givenTypeId = givenCategory.id!!
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        `when`(
+                categoryRepository.findById(givenRequest.typeId)
+        ).thenReturn(
+                Optional.of(givenCategory)
+        )
+        `when`(
+                optionRepository.findByName(givenRequest.name)
+        ).thenReturn(
+                Optional.empty()
+        )
+        // when & then
+        assertDoesNotThrow { optionService.createOption(givenRequest) }
+    }
+
+    @Test
+    fun 존재하지_않는_카테고리_타입의_새로운_옵션을_생성한다() {
+        // given
+        val givenOptionType = OptionType.CATEGORY
+        val givenCategory = fixtureCategoryCoffee
+        val givenTypeId = givenCategory.id!!
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        `when`(
+                categoryRepository.findById(givenRequest.typeId)
+        ).thenReturn(
+                Optional.empty()
+        )
+        // when
+        val assertThrows = assertThrows(CategoryException::class.java) { optionService.createOption(givenRequest) }
+        // when & then
+        assertEquals(assertThrows.message, MSG_CATEGORY_NOT_EXISTS)
+    }
+
+    @Test
+    fun 메뉴_타입의_새로운_옵션을_생성한다() {
+        // given
+        val givenOptionType = OptionType.MENU
+        val givenMenu = fixtureMenuAmericano
+        val givenTypeId = givenMenu.id!!
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        `when`(
+                menuRepository.findById(givenRequest.typeId)
+        ).thenReturn(
+                Optional.of(givenMenu)
+        )
+        `when`(
+                optionRepository.findByName(givenRequest.name)
+        ).thenReturn(
+                Optional.empty()
+        )
+        // when & then
+        assertDoesNotThrow { optionService.createOption(givenRequest) }
+    }
+
+    @Test
+    fun 존재하지_않는_메뉴_타입의_새로운_옵션을_생성한다() {
+    // given
+        val givenOptionType = OptionType.MENU
+        val givenMenu = fixtureMenuAmericano
+        val givenTypeId = givenMenu.id!!
+        val givenName = "새로운 옵션"
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        `when`(
+                menuRepository.findById(givenRequest.typeId)
+        ).thenReturn(
+                Optional.empty()
+        )
+        // when
+        val assertThrows = assertThrows(MenuException::class.java) { optionService.createOption(givenRequest) }
+        // when & then
+        assertEquals(assertThrows.message, MSG_MENU_NOT_EXISTS)
+    }
+
+    @Test
+    fun 존재하는_옵션명으로_생성한다() {
+        // given
+        val givenOptionType = OptionType.MENU
+        val givenMenu = fixtureMenuAmericano
+        val givenTypeId = givenMenu.id!!
+        val givenName = fixtureOptionShot.name
+        val givenDisplayOrder = 1
+        val givenRequest = OptionCreateRequest(
+                type = givenOptionType,
+                typeId = givenTypeId,
+                name = givenName,
+                displayOrder = givenDisplayOrder,
+                subOptions = SubOptionCreateRequest(
+                        values = mutableListOf(
+                                SubOptionValue(name = "하위 옵션", price = 1000, displayOrder = 1)
+                        )
+                )
+        )
+        `when`(
+                menuRepository.findById(givenRequest.typeId)
+        ).thenReturn(
+                Optional.of(givenMenu)
+        )
+        `when`(
+                optionRepository.findByName(givenRequest.name)
+        ).thenReturn(
+                Optional.of(fixtureOptionShot)
+        )
+        // when
+        val assertThrows = assertThrows(OptionException::class.java) { optionService.createOption(givenRequest) }
+        // when & then
+        assertEquals(assertThrows.message, MSG_OPTION_ALREADY_EXISTS)
+    }
+
+    @Test
+    fun 특정_메뉴의_옵션을_조회한다() {
+        // given
+        val givenMenu = fixtureMenuAmericano
+        val givenParentCategories = fixtureCategoryCaffeineRecursiveParentCategories
+        val givenOptions = fixtureOptionsAmericano
+        val givenOptionNames = givenOptions.map { it.name }
+        val givenRequest = OptionGetRequest(menuId = givenMenu.id!!)
+        `when`(
+                menuRepository.findById(givenMenu.id!!)
+        ).thenReturn(
+                Optional.of(givenMenu)
+        )
+        `when`(
+                categoryRepository.findParentCategoriesRecursiveById(givenMenu.category.id!!)
+        ).thenReturn(
+                givenParentCategories.toMutableSet()
+        )
+        `when`(
+                optionRepository.findOptionsByCategoryIdInAndMenuId(
+                        categoryIds = givenParentCategories.map { it.id!! }.toMutableList(),
+                        menuId = givenMenu.id!!)
+        ).thenReturn(
+                fixtureOptionsAmericano
+        )
+        // when
+        val expected = optionService.getByMenuId(optionGetRequest = givenRequest)
+        val expectedOptionNames = expected.list.map { it.name }
+        // then
+        assertAll(
+                { assertEquals(givenOptions.size, expected.list.size) },
+                { assertTrue(givenOptionNames.containsAll(expectedOptionNames)) },
+                { assertTrue(expectedOptionNames.containsAll(givenOptionNames)) },
+        )
+    }
+
+    @Test
+    fun 존재하지_않는_메뉴의_옵션을_조회한다() {
+        // given
+        val givenMenu = fixtureMenuAmericano
+        val givenParentCategories = fixtureCategoryCaffeineRecursiveParentCategories
+        val givenOptions = fixtureOptionsAmericano
+        val givenOptionNames = givenOptions.map { it.name }
+        val givenRequest = OptionGetRequest(menuId = givenMenu.id!!)
+        `when`(
+                menuRepository.findById(givenMenu.id!!)
+        ).thenReturn(
+                Optional.empty()
+        )
+        // when
+        val assertThrows = assertThrows(MenuException::class.java) { optionService.getByMenuId(optionGetRequest = givenRequest) }
+        // then
+        assertEquals(assertThrows.message, MSG_MENU_NOT_EXISTS)
+    }
+}

--- a/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/Category.kt
+++ b/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/Category.kt
@@ -29,7 +29,10 @@ class Category(
     var parent: Category? = null,
 
     @OneToMany(mappedBy = "parent", cascade = [CascadeType.REMOVE], orphanRemoval = true)
-    val subCategories: MutableList<Category> = mutableListOf()
+    val subCategories: MutableList<Category> = mutableListOf(),
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE], orphanRemoval = true, mappedBy = "category")
+    val options: MutableList<Option> = mutableListOf(),
 ) {
     fun changeName(name: String) {
         this.name = name
@@ -69,6 +72,14 @@ class Category(
         return this.subCategories.size > 0
     }
 
+    fun addOption(option: Option) {
+        this.options.add(option)
+    }
+
+    fun removeOption(option: Option) {
+        this.options.remove(option)
+    }
+
     override fun equals(other: Any?): Boolean {
         return if (other is Category) {
             this.name == other.name
@@ -76,6 +87,12 @@ class Category(
     }
 
     override fun toString(): String {
-        return "Category[id: ${this.id}, name: ${this.name}, parent: ${this.parent?.name}, subCategories: ${this.subCategories}]"
+        return "Category[" +
+                    "id: ${this.id}, " +
+                    "name: ${this.name}, " +
+                    "parent: ${this.parent?.name}, " +
+                    "subCategories: ${this.subCategories}, " +
+                    "options: ${this.options}" +
+                "]"
     }
 }

--- a/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/Menu.kt
+++ b/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/Menu.kt
@@ -1,12 +1,15 @@
 package com.devh.cafe.infrastructure.database.entity
 
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 
 @Entity
@@ -27,6 +30,9 @@ class Menu(
     @ManyToOne
     @JoinColumn(name = "category_id")
     var category: Category,
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE], orphanRemoval = true, mappedBy = "menu")
+    val options: MutableList<Option> = mutableListOf(),
 ) {
     init {
         this.category.addMenu(this)
@@ -62,6 +68,14 @@ class Menu(
         category.addMenu(this)
     }
 
+    fun addOption(option: Option) {
+        this.options.add(option)
+    }
+
+    fun removeOption(option: Option) {
+        this.options.remove(option)
+    }
+
     override fun equals(other: Any?): Boolean {
         return if (other is Menu) {
             other.name == this.name
@@ -69,6 +83,13 @@ class Menu(
     }
 
     override fun toString(): String {
-        return "Menu[id: ${this.id}, category: ${this.category.name} name: ${this.name}, price: ${this.price}, available: ${this.available}]"
+        return "Menu[" +
+                    "id: ${this.id}, " +
+                    "category: ${this.category.name}, " +
+                    "name: ${this.name}, " +
+                    "price: ${this.price}, " +
+                    "available: ${this.available}, " +
+                    "options: ${this.options}" +
+                "]"
     }
 }

--- a/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/Option.kt
+++ b/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/Option.kt
@@ -1,0 +1,76 @@
+package com.devh.cafe.infrastructure.database.entity
+
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "option")
+class Option(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, unique = true)
+    val name: String,
+
+    @Column(nullable = false)
+    val displayOrder: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val type: OptionType,
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @JoinColumn(name = "menu_id")
+    val menu: Menu? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @JoinColumn(name = "category_id")
+    val category: Category? = null,
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE], orphanRemoval = true, mappedBy = "option")
+    val subOptions: MutableList<SubOption> = mutableListOf(),
+) {
+
+    init {
+        menu?.addOption(this)
+        category?.addOption(this)
+    }
+
+    fun addSubOption(subOption: SubOption) {
+        this.subOptions.add(subOption)
+    }
+
+    fun removeSubOption(subOption: SubOption) {
+        this.subOptions.remove(subOption)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return if (other is Option) {
+            other.name == this.name
+        } else false
+    }
+
+    override fun toString(): String {
+        return "Option[" +
+                    "id: ${this.id}, " +
+                    "name: ${this.name}, " +
+                    "displayOrder: ${this.displayOrder}, " +
+                    "type: ${this.type}, " +
+                    "menu: ${this.menu?.name}, " +
+                    "category: ${this.category?.name}, " +
+                    "subOptions: ${this.subOptions}, " +
+                "]"
+    }
+}

--- a/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/SubOption.kt
+++ b/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/SubOption.kt
@@ -1,0 +1,53 @@
+package com.devh.cafe.infrastructure.database.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "sub_option")
+class SubOption(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, unique = true)
+    val name: String,
+
+    @Column(nullable = false)
+    val price: Long,
+
+    @Column(nullable = false)
+    val displayOrder: Int,
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @JoinColumn(name = "option_id")
+    val option: Option,
+) {
+
+    init {
+        option.addSubOption(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return if (other is SubOption) {
+            other.name == this.name
+        } else false
+    }
+
+    override fun toString(): String {
+        return "SubOption[" +
+                    "id: ${this.id}, " +
+                    "name: ${this.name}, " +
+                    "price: ${this.price}, " +
+                    "displayOrder: ${this.displayOrder}, " +
+                    "option: ${this.option.name}, " +
+                "]"
+    }
+}

--- a/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/enums/OptionType.kt
+++ b/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/entity/enums/OptionType.kt
@@ -1,0 +1,6 @@
+package com.devh.cafe.infrastructure.database.entity.enums
+
+enum class OptionType {
+    CATEGORY,
+    MENU,
+}

--- a/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/fixture/CategoryFixture.kt
+++ b/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/fixture/CategoryFixture.kt
@@ -17,6 +17,9 @@ val fixtureCategoryBeverageRecursiveSubCategories = mutableListOf(fixtureCategor
                                                                   fixtureCategoryFlatccino,
                                                                   fixtureCategoryCaffeine,
                                                                   fixtureCategoryDecaffeine)
+val fixtureCategoryCaffeineRecursiveParentCategories = mutableListOf(fixtureCategoryCaffeine,
+                                                                     fixtureCategoryCoffee,
+                                                                     fixtureCategoryBeverage)
 val fixtureCategoryAll = mutableListOf(fixtureCategoryAlcohol,
                                        fixtureCategoryBeverage,
                                        fixtureCategoryBakery,

--- a/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/fixture/OptionFixture.kt
+++ b/infrastructure/database/src/main/kotlin/com/devh/cafe/infrastructure/database/fixture/OptionFixture.kt
@@ -1,0 +1,27 @@
+package com.devh.cafe.infrastructure.database.fixture
+
+import com.devh.cafe.infrastructure.database.entity.Option
+import com.devh.cafe.infrastructure.database.entity.SubOption
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+
+val fixtureOptionIceHot = Option(id = 3001, name = "아이스/핫", type = OptionType.CATEGORY, menu = null, category = fixtureCategoryBeverage, displayOrder = 1)
+val fixtureOptionShot = Option(id = 3002, name = "샷", type = OptionType.CATEGORY, menu = null, category = fixtureCategoryCoffee, displayOrder = 1)
+val fixtureOptionBean = Option(id = 3003, name = "원두", type = OptionType.CATEGORY, menu = null, category = fixtureCategoryCoffee, displayOrder = 2)
+val fixtureOptionSugar = Option(id = 3004, name = "당도", type = OptionType.CATEGORY, menu = null, category = fixtureCategoryFlatccino, displayOrder = 1)
+val fixtureOptionMilk = Option(id = 3005, name = "원유", type = OptionType.MENU, menu = fixtureMenuLatte, category = null, displayOrder = 1)
+val fixtureSubOptionIce = SubOption(id = 4001, name = "아이스", price = 500, displayOrder = 1, option = fixtureOptionIceHot)
+val fixtureSubOptionHot = SubOption(id = 4002, name = "핫", price = 0, displayOrder = 2, option = fixtureOptionIceHot)
+val fixtureSubOptionDefaultShot = SubOption(id = 4003, name = "기본", price = 0, displayOrder = 1, option = fixtureOptionShot)
+val fixtureSubOptionOneShot = SubOption(id = 4004, name = "1샷", price = 500, displayOrder = 2, option = fixtureOptionShot)
+val fixtureSubOptionTwoShot = SubOption(id = 4005, name = "2샷", price = 1000, displayOrder = 3, option = fixtureOptionShot)
+val fixtureSubOptionDarkBean = SubOption(id = 4006, name = "다크", price = 0, displayOrder = 1, option = fixtureOptionBean)
+val fixtureSubOptionAcidBean = SubOption(id = 4007, name = "산미", price = 0, displayOrder = 2, option = fixtureOptionBean)
+val fixtureSubOptionMoreSugar = SubOption(id = 4008, name = "더 달게", price = 0, displayOrder = 1, option = fixtureOptionSugar)
+val fixtureSubOptionLessSugar = SubOption(id = 4009, name = "덜 달게", price = 0, displayOrder = 2, option = fixtureOptionSugar)
+val fixtureSubOptionOriginalMilk = SubOption(id = 4010, name = "우유", price = 0, displayOrder = 1, option = fixtureOptionMilk)
+val fixtureSubOptionSoyMilk = SubOption(id = 4011, name = "두유", price = 0, displayOrder = 2, option = fixtureOptionMilk)
+val fixtureSubOptionOatMilk = SubOption(id = 4012, name = "오트밀", price = 0, displayOrder = 3, option = fixtureOptionMilk)
+
+val fixtureOptionsAmericano = mutableListOf(
+        fixtureOptionIceHot, fixtureOptionShot, fixtureOptionBean
+)

--- a/infrastructure/database/src/test/kotlin/com/devh/cafe/infrastructure/database/entity/OptionTest.kt
+++ b/infrastructure/database/src/test/kotlin/com/devh/cafe/infrastructure/database/entity/OptionTest.kt
@@ -1,0 +1,178 @@
+package com.devh.cafe.infrastructure.database.entity
+
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class OptionTest {
+
+    @Test
+    fun 타입이_메뉴인_옵션을_1개_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "커피"),
+        )
+        val givenName = "샷 옵션"
+        val givenDisplayOrder = 1
+        val givenType = OptionType.MENU
+        // when
+        val option = Option(
+            name = givenName,
+            displayOrder = givenDisplayOrder,
+            type = OptionType.MENU,
+            menu = givenMenu,
+        )
+        println(option)
+        // then
+        assertAll(
+            { assertEquals(givenName, option.name) },
+            { assertEquals(givenDisplayOrder, option.displayOrder) },
+            { assertEquals(givenType, option.type) },
+            { assertEquals(givenMenu.options[0], option) },
+        )
+    }
+
+    @Test
+    fun 타입이_메뉴인_옵션을_3개_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "커피"),
+        )
+        val givenType = OptionType.MENU
+
+        val givenName1 = "샷 옵션"
+        val givenDisplayOrder1 = 1
+
+        val givenName2 = "블렌딩 옵션"
+        val givenDisplayOrder2 = 2
+
+        val givenName3 = "디카페인 옵션"
+        val givenDisplayOrder3 = 3
+
+        // when
+        val option1 = Option(
+            name = givenName1,
+            displayOrder = givenDisplayOrder1,
+            type = givenType,
+            menu = givenMenu,
+        )
+        val option2 = Option(
+            name = givenName2,
+            displayOrder = givenDisplayOrder2,
+            type = givenType,
+            menu = givenMenu,
+        )
+        val option3 = Option(
+            name = givenName3,
+            displayOrder = givenDisplayOrder3,
+            type = givenType,
+            menu = givenMenu,
+        )
+        println(option1)
+        println(option2)
+        println(option3)
+        // then
+        assertAll(
+            { assertEquals(givenName1, option1.name) },
+            { assertEquals(givenDisplayOrder1, option1.displayOrder) },
+            { assertEquals(givenType, option1.type) },
+            { assertEquals(givenMenu.options[0], option1) },
+
+            { assertEquals(givenName2, option2.name) },
+            { assertEquals(givenDisplayOrder2, option2.displayOrder) },
+            { assertEquals(givenType, option2.type) },
+            { assertEquals(givenMenu.options[1], option2) },
+
+            { assertEquals(givenName3, option3.name) },
+            { assertEquals(givenDisplayOrder3, option3.displayOrder) },
+            { assertEquals(givenType, option3.type) },
+            { assertEquals(givenMenu.options[2], option3) },
+        )
+    }
+
+    @Test
+    fun 타입이_카테고리인_옵션을_1개_생성한다() {
+        // given
+        val givenCategory = Category(name = "음료")
+        val givenName = "아이스 옵션"
+        val givenDisplayOrder = 1
+        val givenType = OptionType.CATEGORY
+        // when
+        val option = Option(
+            name = givenName,
+            displayOrder = givenDisplayOrder,
+            type = givenType,
+            category = givenCategory,
+        )
+        println(option)
+        // then
+        assertAll(
+            { assertEquals(givenName, option.name) },
+            { assertEquals(givenDisplayOrder, option.displayOrder) },
+            { assertEquals(givenType, option.type) },
+            { assertEquals(givenCategory.options[0], option) },
+        )
+    }
+
+    @Test
+    fun 타입이_카테고리인_옵션을_3개_생성한다() {
+        // given
+        val givenCategory = Category(name = "음료")
+        val givenType = OptionType.CATEGORY
+
+        val givenName1 = "아이스 옵션"
+        val givenDisplayOrder1 = 1
+
+        val givenName2 = "텀블러 옵션"
+        val givenDisplayOrder2 = 2
+
+        val givenName3 = "사이즈 옵션"
+        val givenDisplayOrder3 = 3
+        // when
+        val option1 = Option(
+            name = givenName1,
+            displayOrder = givenDisplayOrder1,
+            type = givenType,
+            category = givenCategory,
+        )
+        val option2 = Option(
+            name = givenName2,
+            displayOrder = givenDisplayOrder2,
+            type = givenType,
+            category = givenCategory,
+        )
+        val option3 = Option(
+            name = givenName3,
+            displayOrder = givenDisplayOrder3,
+            type = givenType,
+            category = givenCategory,
+        )
+        println(option1)
+        println(option2)
+        println(option3)
+        // then
+        assertAll(
+            { assertEquals(givenName1, option1.name) },
+            { assertEquals(givenDisplayOrder1, option1.displayOrder) },
+            { assertEquals(givenType, option1.type) },
+            { assertEquals(givenCategory.options[0], option1) },
+
+            { assertEquals(givenName2, option2.name) },
+            { assertEquals(givenDisplayOrder2, option2.displayOrder) },
+            { assertEquals(givenType, option2.type) },
+            { assertEquals(givenCategory.options[1], option2) },
+
+            { assertEquals(givenName3, option3.name) },
+            { assertEquals(givenDisplayOrder3, option3.displayOrder) },
+            { assertEquals(givenType, option3.type) },
+            { assertEquals(givenCategory.options[2], option3) },
+        )
+    }
+}

--- a/infrastructure/database/src/test/kotlin/com/devh/cafe/infrastructure/database/entity/SubOptionTest.kt
+++ b/infrastructure/database/src/test/kotlin/com/devh/cafe/infrastructure/database/entity/SubOptionTest.kt
@@ -1,0 +1,459 @@
+package com.devh.cafe.infrastructure.database.entity
+
+import com.devh.cafe.infrastructure.database.entity.enums.OptionType
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SubOptionTest {
+
+    @Test
+    fun 타입이_메뉴인_옵션의_하위_옵션을_1개_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "커피"),
+        )
+        val givenOption = Option(
+            name = "샷 옵션",
+            displayOrder = 1,
+            type = OptionType.MENU,
+            menu = givenMenu,
+        )
+        val givenName = "1샷 추가"
+        val givenPrice = 500L
+        val givenDisplayOrder = 1
+        // when
+        val subOption = SubOption(
+            name = givenName,
+            price = givenPrice,
+            displayOrder = givenDisplayOrder,
+            option = givenOption
+        )
+        println(subOption)
+        // then
+        assertAll(
+            { assertEquals(givenName, subOption.name) },
+            { assertEquals(givenPrice, subOption.price) },
+            { assertEquals(givenDisplayOrder, subOption.displayOrder) },
+            { assertEquals(givenOption, subOption.option) },
+            { assertEquals(givenOption.type, subOption.option.type) },
+        )
+    }
+
+    @Test
+    fun 타입이_메뉴인_옵션의_하위_옵션을_3개_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "커피"),
+        )
+        val givenOption = Option(
+            name = "샷 옵션",
+            displayOrder = 1,
+            type = OptionType.MENU,
+            menu = givenMenu,
+        )
+
+        val givenName1 = "1샷 추가"
+        val givenPrice1 = 500L
+        val givenDisplayOrder1 = 1
+
+        val givenName2 = "2샷 추가"
+        val givenPrice2 = 1000L
+        val givenDisplayOrder2 = 2
+
+        val givenName3 = "1/2 샷"
+        val givenPrice3 = 0L
+        val givenDisplayOrder3 = 3
+
+        // when
+        val subOption1 = SubOption(
+            name = givenName1,
+            price = givenPrice1,
+            displayOrder = givenDisplayOrder1,
+            option = givenOption
+        )
+        val subOption2 = SubOption(
+            name = givenName2,
+            price = givenPrice2,
+            displayOrder = givenDisplayOrder2,
+            option = givenOption
+        )
+        val subOption3 = SubOption(
+            name = givenName3,
+            price = givenPrice3,
+            displayOrder = givenDisplayOrder3,
+            option = givenOption
+        )
+        println(subOption1)
+        println(subOption2)
+        println(subOption3)
+        // then
+        assertAll(
+            { assertEquals(givenName1, subOption1.name) },
+            { assertEquals(givenPrice1, subOption1.price) },
+            { assertEquals(givenDisplayOrder1, subOption1.displayOrder) },
+            { assertEquals(givenOption, subOption1.option) },
+            { assertEquals(givenOption.type, subOption1.option.type) },
+
+            { assertEquals(givenName2, subOption2.name) },
+            { assertEquals(givenPrice2, subOption2.price) },
+            { assertEquals(givenDisplayOrder2, subOption2.displayOrder) },
+            { assertEquals(givenOption, subOption2.option) },
+            { assertEquals(givenOption.type, subOption2.option.type) },
+
+            { assertEquals(givenName3, subOption3.name) },
+            { assertEquals(givenPrice3, subOption3.price) },
+            { assertEquals(givenDisplayOrder3, subOption3.displayOrder) },
+            { assertEquals(givenOption, subOption3.option) },
+            { assertEquals(givenOption.type, subOption3.option.type) },
+        )
+    }
+
+    @Test
+    fun 타입이_메뉴인_2개의_옵션에_각각_1개_2개의_하위_옵션을_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "커피"),
+        )
+        val givenOption1 = Option(
+            name = "샷 옵션",
+            displayOrder = 1,
+            type = OptionType.MENU,
+            menu = givenMenu,
+        )
+        val givenOption2 = Option(
+            name = "디카페인 옵션",
+            displayOrder = 2,
+            type = OptionType.MENU,
+            menu = givenMenu,
+        )
+
+        val givenName1 = "1샷 추가"
+        val givenPrice1 = 500L
+        val givenDisplayOrder1 = 1
+
+        val givenName2 = "2샷 추가"
+        val givenPrice2 = 1000L
+        val givenDisplayOrder2 = 2
+
+        val givenName3 = "디카페인"
+        val givenPrice3 = 500L
+        val givenDisplayOrder3 = 1
+
+        // when
+        val subOption1 = SubOption(
+            name = givenName1,
+            price = givenPrice1,
+            displayOrder = givenDisplayOrder1,
+            option = givenOption1
+        )
+        val subOption2 = SubOption(
+            name = givenName2,
+            price = givenPrice2,
+            displayOrder = givenDisplayOrder2,
+            option = givenOption1
+        )
+        val subOption3 = SubOption(
+            name = givenName3,
+            price = givenPrice3,
+            displayOrder = givenDisplayOrder3,
+            option = givenOption2
+        )
+        println(subOption1)
+        println(subOption2)
+        println(subOption3)
+        // then
+        assertAll(
+            { assertEquals(givenName1, subOption1.name) },
+            { assertEquals(givenPrice1, subOption1.price) },
+            { assertEquals(givenDisplayOrder1, subOption1.displayOrder) },
+            { assertEquals(givenOption1, subOption1.option) },
+            { assertEquals(givenOption1.type, subOption1.option.type) },
+
+            { assertEquals(givenName2, subOption2.name) },
+            { assertEquals(givenPrice2, subOption2.price) },
+            { assertEquals(givenDisplayOrder2, subOption2.displayOrder) },
+            { assertEquals(givenOption1, subOption2.option) },
+            { assertEquals(givenOption1.type, subOption2.option.type) },
+
+            { assertEquals(givenName3, subOption3.name) },
+            { assertEquals(givenPrice3, subOption3.price) },
+            { assertEquals(givenDisplayOrder3, subOption3.displayOrder) },
+            { assertEquals(givenOption2, subOption3.option) },
+            { assertEquals(givenOption2.type, subOption3.option.type) },
+        )
+    }
+
+    @Test
+    fun 타입이_카테고리인_옵션의_하위_옵션을_1개_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "음료"),
+        )
+        val givenOption = Option(
+            name = "아이스 옵션",
+            displayOrder = 1,
+            type = OptionType.CATEGORY,
+            menu = givenMenu,
+        )
+        val givenName = "아이스"
+        val givenPrice = 500L
+        val givenDisplayOrder = 1
+        // when
+        val subOption = SubOption(
+            name = givenName,
+            price = givenPrice,
+            displayOrder = givenDisplayOrder,
+            option = givenOption
+        )
+        println(subOption)
+        // then
+        assertAll(
+            { assertEquals(givenName, subOption.name) },
+            { assertEquals(givenPrice, subOption.price) },
+            { assertEquals(givenDisplayOrder, subOption.displayOrder) },
+            { assertEquals(givenOption, subOption.option) },
+            { assertEquals(givenOption.type, subOption.option.type) },
+        )
+    }
+
+    @Test
+    fun 타입이_카테고리인_옵션의_하위_옵션을_3개_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "음료"),
+        )
+        val givenOption = Option(
+            name = "얼음 옵션",
+            displayOrder = 1,
+            type = OptionType.CATEGORY,
+            menu = givenMenu,
+        )
+
+        val givenName1 = "얼음 많게"
+        val givenPrice1 = 0L
+        val givenDisplayOrder1 = 1
+
+        val givenName2 = "얼음 보통"
+        val givenPrice2 = 0L
+        val givenDisplayOrder2 = 2
+
+        val givenName3 = "얼음 많이"
+        val givenPrice3 = 0L
+        val givenDisplayOrder3 = 3
+
+        // when
+        val subOption1 = SubOption(
+            name = givenName1,
+            price = givenPrice1,
+            displayOrder = givenDisplayOrder1,
+            option = givenOption
+        )
+        val subOption2 = SubOption(
+            name = givenName2,
+            price = givenPrice2,
+            displayOrder = givenDisplayOrder2,
+            option = givenOption
+        )
+        val subOption3 = SubOption(
+            name = givenName3,
+            price = givenPrice3,
+            displayOrder = givenDisplayOrder3,
+            option = givenOption
+        )
+        println(subOption1)
+        println(subOption2)
+        println(subOption3)
+        // then
+        assertAll(
+            { assertEquals(givenName1, subOption1.name) },
+            { assertEquals(givenPrice1, subOption1.price) },
+            { assertEquals(givenDisplayOrder1, subOption1.displayOrder) },
+            { assertEquals(givenOption, subOption1.option) },
+            { assertEquals(givenOption.type, subOption1.option.type) },
+
+            { assertEquals(givenName2, subOption2.name) },
+            { assertEquals(givenPrice2, subOption2.price) },
+            { assertEquals(givenDisplayOrder2, subOption2.displayOrder) },
+            { assertEquals(givenOption, subOption2.option) },
+            { assertEquals(givenOption.type, subOption2.option.type) },
+
+            { assertEquals(givenName3, subOption3.name) },
+            { assertEquals(givenPrice3, subOption3.price) },
+            { assertEquals(givenDisplayOrder3, subOption3.displayOrder) },
+            { assertEquals(givenOption, subOption3.option) },
+            { assertEquals(givenOption.type, subOption3.option.type) },
+        )
+    }
+
+    @Test
+    fun 타입이_카테고리인_2개의_옵션에_각각_1개_2개의_하위_옵션을_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "음료"),
+        )
+        val givenOption1 = Option(
+            name = "얼음 옵션",
+            displayOrder = 1,
+            type = OptionType.CATEGORY,
+            menu = givenMenu,
+        )
+        val givenOption2 = Option(
+            name = "사이즈 옵션",
+            displayOrder = 2,
+            type = OptionType.CATEGORY,
+            menu = givenMenu,
+        )
+
+        val givenName1 = "얼음 보통"
+        val givenPrice1 = 0L
+        val givenDisplayOrder1 = 1
+
+        val givenName2 = "얼음 많이"
+        val givenPrice2 = 0L
+        val givenDisplayOrder2 = 2
+
+        val givenName3 = "사이즈업"
+        val givenPrice3 = 500L
+        val givenDisplayOrder3 = 1
+
+        // when
+        val subOption1 = SubOption(
+            name = givenName1,
+            price = givenPrice1,
+            displayOrder = givenDisplayOrder1,
+            option = givenOption1
+        )
+        val subOption2 = SubOption(
+            name = givenName2,
+            price = givenPrice2,
+            displayOrder = givenDisplayOrder2,
+            option = givenOption1
+        )
+        val subOption3 = SubOption(
+            name = givenName3,
+            price = givenPrice3,
+            displayOrder = givenDisplayOrder3,
+            option = givenOption2
+        )
+        println(subOption1)
+        println(subOption2)
+        println(subOption3)
+        // then
+        assertAll(
+            { assertEquals(givenName1, subOption1.name) },
+            { assertEquals(givenPrice1, subOption1.price) },
+            { assertEquals(givenDisplayOrder1, subOption1.displayOrder) },
+            { assertEquals(givenOption1, subOption1.option) },
+            { assertEquals(givenOption1.type, subOption1.option.type) },
+
+            { assertEquals(givenName2, subOption2.name) },
+            { assertEquals(givenPrice2, subOption2.price) },
+            { assertEquals(givenDisplayOrder2, subOption2.displayOrder) },
+            { assertEquals(givenOption1, subOption2.option) },
+            { assertEquals(givenOption1.type, subOption2.option.type) },
+
+            { assertEquals(givenName3, subOption3.name) },
+            { assertEquals(givenPrice3, subOption3.price) },
+            { assertEquals(givenDisplayOrder3, subOption3.displayOrder) },
+            { assertEquals(givenOption2, subOption3.option) },
+            { assertEquals(givenOption2.type, subOption3.option.type) },
+        )
+    }
+
+    @Test
+    fun 타입이_메뉴와_카테고리_각각인_옵션에_각각_1개_2개의_하위_옵션을_생성한다() {
+        // given
+        val givenMenu = Menu(
+            name = "아메리카노",
+            price = 4100L,
+            available = true,
+            category = Category(name = "음료"),
+        )
+        val givenOption1 = Option(
+            name = "얼음 옵션",
+            displayOrder = 1,
+            type = OptionType.CATEGORY,
+            menu = givenMenu,
+        )
+        val givenOption2 = Option(
+            name = "샷 옵션",
+            displayOrder = 2,
+            type = OptionType.MENU,
+            menu = givenMenu,
+        )
+
+        val givenName1 = "얼음 보통"
+        val givenPrice1 = 0L
+        val givenDisplayOrder1 = 1
+
+        val givenName2 = "얼음 많이"
+        val givenPrice2 = 0L
+        val givenDisplayOrder2 = 2
+
+        val givenName3 = "1샷 추가"
+        val givenPrice3 = 500L
+        val givenDisplayOrder3 = 1
+
+        // when
+        val subOption1 = SubOption(
+            name = givenName1,
+            price = givenPrice1,
+            displayOrder = givenDisplayOrder1,
+            option = givenOption1
+        )
+        val subOption2 = SubOption(
+            name = givenName2,
+            price = givenPrice2,
+            displayOrder = givenDisplayOrder2,
+            option = givenOption1
+        )
+        val subOption3 = SubOption(
+            name = givenName3,
+            price = givenPrice3,
+            displayOrder = givenDisplayOrder3,
+            option = givenOption2
+        )
+        println(subOption1)
+        println(subOption2)
+        println(subOption3)
+        // then
+        assertAll(
+            { assertEquals(givenName1, subOption1.name) },
+            { assertEquals(givenPrice1, subOption1.price) },
+            { assertEquals(givenDisplayOrder1, subOption1.displayOrder) },
+            { assertEquals(givenOption1, subOption1.option) },
+            { assertEquals(givenOption1.type, subOption1.option.type) },
+
+            { assertEquals(givenName2, subOption2.name) },
+            { assertEquals(givenPrice2, subOption2.price) },
+            { assertEquals(givenDisplayOrder2, subOption2.displayOrder) },
+            { assertEquals(givenOption1, subOption2.option) },
+            { assertEquals(givenOption1.type, subOption2.option.type) },
+
+            { assertEquals(givenName3, subOption3.name) },
+            { assertEquals(givenPrice3, subOption3.price) },
+            { assertEquals(givenDisplayOrder3, subOption3.displayOrder) },
+            { assertEquals(givenOption2, subOption3.option) },
+            { assertEquals(givenOption2.type, subOption3.option.type) },
+        )
+    }
+}


### PR DESCRIPTION
[[CAFE-12] Feat: option, sub_option 엔티티 및 상수, fixture 클래스 작성 - menu와 category에 연관관계를 갖는다. [infrastructure-database]](https://github.com/kimheonseung/cafe/commit/16d6d672e1f4f149ec8066c8345f0485aefec13f)
[[CAFE-12] Feat: category repository 수정 - 상위 카테고리를 추적하여 조회하는 기능 추가](https://github.com/kimheonseung/cafe/commit/12dc1ba4e9c2400f459f08f5607d0cd585fc482e)
[[CAFE-12] Feat: category service 수정 - 상위 카테고리를 추적하여 조회하는 기능 추가](https://github.com/kimheonseung/cafe/commit/b386f5fef1146ad86457c99497111619dd57d217)
[[CAFE-12] Feat: menu repository 수정 - 특정 카테고리 하위의 모든 메뉴를 조회하기 위한 기능 추가](https://github.com/kimheonseung/cafe/commit/7daf4be41445ee23472763fb37baa4883430f310)
[[CAFE-12] Feat: menu service 수정 - 특정 카테고리 하위의 모든 메뉴를 조회하도록 변경](https://github.com/kimheonseung/cafe/commit/b299871642522c4e26f95f17f8fc08f5083fafa6)
[[CAFE-12] Feat: menu controller 수정 - 반환 응답 형식 변경에 따른 테스트 코드 수정](https://github.com/kimheonseung/cafe/commit/96a462a195fb885bca674bd8134adcd595d82487)
[[CAFE-12] Feat: option 레파지토리 작성](https://github.com/kimheonseung/cafe/commit/a18b7259f0974ef8eadfd29db8c3b626547871ea)
[[CAFE-12] Feat: option, sub_option 관련 예외 작성](https://github.com/kimheonseung/cafe/commit/249566f925d3de08772eeea0bb84e32412bb3265)
[[CAFE-12] Feat: option 서비스 작성](https://github.com/kimheonseung/cafe/commit/f9407ee12bb83e8a0ebe8ad59c6691cd5a137665)
[[CAFE-12] Feat: option 컨트롤러 작성](https://github.com/kimheonseung/cafe/commit/cf66d4891f9c5f9fdcd8ca7aea1d3e234d6ceb6e)